### PR TITLE
add warning about special characters being filtered from Slack messages

### DIFF
--- a/content/en/xtc/integrations/510-slack.md
+++ b/content/en/xtc/integrations/510-slack.md
@@ -94,6 +94,10 @@ If a complete configuration (i.e. integration data and target channels) is avail
 
 Once configured XTC will send notifications for the following events:
 
+{{% warning notitle %}}
+Due to limitations in Slack's text renderer certain control characters will be filtered from the input values when displaying them in messages. If any of your organization's, project's, load test's or report's names containes any of the following characters, these may be removed: `_`, `*`, `` ` `` or `~`.
+{{% /warning %}}
+
 ### Load Tests
   * **Start** A user started a load test from the UI.
   * **Running** The setup phase is complete; the actual test run starts.

--- a/content/en/xtc/integrations/510-slack.md
+++ b/content/en/xtc/integrations/510-slack.md
@@ -92,11 +92,11 @@ If a complete configuration (i.e. integration data and target channels) is avail
 
 ## Notification Events
 
-Once configured XTC will send notifications for the following events:
-
 {{% warning notitle %}}
-Due to limitations in Slack's text renderer certain control characters will be filtered from the input values when displaying them in messages. If any of your organization's, project's, load test's or report's names containes any of the following characters, these may be removed: `_`, `*`, `` ` `` or `~`.
+Due to limitations in Slack's text renderer certain control characters (`_`, `*`, `` ` `` or `~`) have to be removed. This applies to organization, project, load test, and report names. XTC does not limit your freedom here when setting up data, but this won't make it into the Slack communication.
 {{% /warning %}}
+
+Once configured XTC will send notifications for the following events:
 
 ### Load Tests
   * **Start** A user started a load test from the UI.


### PR DESCRIPTION
Our Slack integration has to filter certain control characters from the messages due to limitations in Slack's message renderer.  This PR adds a small note to the Slack documentation to warn users of using certain characters in organization, project etc. names.